### PR TITLE
Sett krav 1.4.4 til ikke testet

### DIFF
--- a/reports/buttons/ActionButton/wcag-1.4.4_endring_av_tekstst_rrelse.yml
+++ b/reports/buttons/ActionButton/wcag-1.4.4_endring_av_tekstst_rrelse.yml
@@ -1,37 +1,12 @@
 ruleId: wcag-1.4.4
-status: godkjent
-versjon:
-  ffe-buttons-react: 16.0.1
-  ffe-buttons: 15.0.2
-enheter:
-  - enhet: Macbook Pro
-    os: MacOS Monterey 12.2.1
-    nettleser: Firefox 100.0
-  - enhet: Macbook Pro
-    os: MacOS Big Sur 11.6.1
-    nettleser: Chrome 101.0.4951.64
-  - enhet: iPhone 11 Pro
-    os: iOS 15.3.1
-    nettleser: Safari 15
-  - enhet: Samsung S20 FE
-    os: Android 12
-    nettleser: Edge 100.0.1185.50
+status: ikke_testet
+versjon: {}
+enheter: []
 varianter: []
 fargemodus: []
 metode:
-  - "I nettleser: Zoom inn til 200% eller sett text scaling til 200%. Sjekk at
-    innholdet i knappen endrer størrelse og fortsatt vises riktig."
+  - I nettleser: Zoom inn til 200% eller sett text scaling til 200%. Sjekk at
+    innholdet i knappen endrer størrelse og fortsatt vises riktig.
   - Inspiser koden og sett font-size på root elementet (f.eks html-tag). Sjekk
-    at teksten endrer størrelse.
-kommentar: "For å skalere tekst i mobilbank-appene for iOS og Android må
-  brukerne endre innstillingene for tekststørrelse i selve OS-et, i
-  tilgjengelighetsinnstillingene. Testene som er gjennomført skal være
-  tilstrekkelige for å teste at komponenten er satt opp riktig for å støtte
-  tekstskalering, inkludert tekstskalering i iOS- og Android-appene. For at
-  tekstskaleringen skal fungere iOS- og Android-appene må fontstørrelsene
-  spesifiseres på en spesiell måte i appene (root-elementet må endre
-  fontstørrelse basert på preferanser fra OS-et:
-  https://dev.to/gualtierofr/dynamic-fonts-in-wkwebview-2c0f). I denne testen
-  sjekker vi at komponenten har støtte for tekstskalering. For at skaleringen
-  skal fungere må utviklerne også spesifiserer fontstørrelsene riktig i appene.
-  Det går utenfor selve komponenten og designsystemet."
+    at teksten endrer størrelse.   
+kommentar: For å ivareta kravet må komponenten støtte skalering av teksten, inkludert skalering når komponenten brukes i webviews i mobilbanken-appene for iOS og Android. For fullverdig test må vi definere hvordan vi tester dette også (i tillegg til metodene som allerede er beskrevet). Kravet står derfor som ikke testet. Lager et issue på å undersøke hvordan vi støtter tekstskalering i webviews på iOS og Android og definere testmetode.


### PR DESCRIPTION
Vi mangler å definere metode for hvordan vi tester at komponenten støtter tekstskalering i webviews på iOS og Android. Lager issue på det og setter kravet til «ikke testet» enn så lenge :)